### PR TITLE
Fixing typos and phrasing

### DIFF
--- a/build.md
+++ b/build.md
@@ -8,18 +8,18 @@
 
 ## Introduction
 
-Compose specification is a platform-neutral way to define multi-container applications. A Compose implementation
-focussing on development use-case to run application on local machine will obviously also support (re)building
-application from sources. The Compose Build specification allows to define the build process within a Compose file
+The Compose specification is a platform-neutral way to define multi-container applications. A Compose implementation
+focusing on development use-cases will obviously support (re)building
+applications from source. The Compose Build specification allows defining the build process within a Compose file
 in a portable way.
 
 ## Definitions
 
-Compose Specification is extended to support an OPTIONAL `build` subsection on services. This section define the
-build requirements for service container image. Only a subset of Compose file services MAY define such a Build
-subsection, others being created based on `Image` attribute. When a Build subsection is present for a service, it
-is *valid* for a Compose file to miss an `Image` attribute for corresponding service, as Compose implementation
-can build image from source.
+The Compose Specification is extended to support an OPTIONAL `build` subsection on services. This section defines the
+build requirements for a service's container image. Only a subset of Compose file services MAY define such a Build
+subsection, with others being created based on the `Image` attribute. When a Build subsection is present for a service, it
+is *valid* for a Compose file to miss an `Image` attribute for the corresponding service, as the Compose implementation
+can build the image from source.
 
 Build can be either specified as a single string defining a context path, or as a detailed build definition.
 
@@ -35,21 +35,20 @@ Dockerfile path is used.
 
 ## Consistency with Image
 
-When service definition do include both `Image` attribute and a `Build` section, Compose implementation can't
-guarantee a pulled image is strictly equivalent to building the same image from sources. Without any explicit
-user directives, Compose implementation with Build support MUST first try to pull Image, then build from source
-if image was not found on registry. Compose implementation MAY offer options to customize this behaviour by user
+When a service definition includes both the `Image` attribute and a `Build` section, a Compose implementation can't
+guarantee a pulled image is strictly equivalent to building the same image from source. Without explicit
+user directives, a Compose implementation with Build support MUST first try to pull the Image, then build from source
+if the image was not found on the registry. A Compose implementation MAY offer options to customize this behaviour by user
 request.
 
 ## Publishing built images
 
-Compose implementation with Build support SHOULD offer an option to push built images to a registry. Doing so, it
-MUST NOT try to push service images without an `Image` attribute. Compose implementation SHOULD warn user about
-missing `Image` attribute which prevent image being pushed.
+A Compose implementation with Build support SHOULD offer an option to push built images to a registry. It
+MUST NOT push service images without an `Image` attribute and instead SHOULD warn the user about
+the missing `Image` attribute.
 
-Compose implementation MAY offer a mechanism to compute an `Image` attribute for service when not explicitly
-declared in yaml file. In such a case, the resulting Compose configuration is considered to have a valid `Image`
-attribute, whenever the actual raw yaml file doesn't explicitly declare one.
+A Compose implementation MAY offer a mechanism to compute an `Image` attribute for a service when it's not explicitly
+declared in the yaml file.
 
 ## Illustrative sample
 
@@ -110,9 +109,9 @@ build:
 
 ### dockerfile
 
-`dockerfile` allows to set an alternate Dockerfile. A relative path MUST be resolved from the build context.
-Compose implementations MUST warn user about absolute path used to define Dockerfile as those prevent Compose file
-for being portable.
+`dockerfile` sets an alternate Dockerfile. A relative path MUST be resolved from the build context.
+Compose implementations MUST warn the user if `dockerfile` is set to an absolute path as those prevent Compose file
+portability.
 
 ```yml
 build:
@@ -122,7 +121,7 @@ build:
 
 ### args
 
-`args` define build arguments, i.e. Dockerfile `ARG` values.
+`args` defines build arguments, i.e. Dockerfile `ARG` values. `args` can be a mapping or a list.
 
 Using following Dockerfile:
 
@@ -131,7 +130,7 @@ ARG GIT_COMMIT
 RUN echo "Based on commit: $GIT_COMMIT"
 ```
 
-`args` can be set in Compose file under the `build` key to define `GIT_COMMIT`. `args` can be set a mapping or a list:
+`args` can define `GIT_COMMIT`:
 
 ```yml
 build:
@@ -147,8 +146,8 @@ build:
     - GIT_COMMIT=cdc3b19
 ```
 
-Value can be omitted when specifying a build argument, in which case its value at build time MUST be obtained by user interaction,
-otherwise build arg won't be set when building the Docker image.
+A value can be omitted when specifying a build argument, in which case its value at build-time MUST be obtained by user interaction,
+otherwise the build arg won't be set when building the Docker image.
 
 ```yml
 args:
@@ -157,7 +156,7 @@ args:
 
 ### cache_from
 
-`cache_from` defines a list of images that the Image builder SHOULD uses for cache resolution.
+`cache_from` defines a list of images that the Image builder SHOULD use for cache resolution.
 
 ```yml
 build:
@@ -177,8 +176,8 @@ extra_hosts:
   - "otherhost:50.31.209.229"
 ```
 
-Compose implementations MUST create matching entry with the IP address and hostname in the container's network
-configuration, which means for Linux `/etc/hosts` will get extra lines:
+Compose implementations MUST create entries with the IP address and hostname in the container's network
+configuration, i.e. for Linux `/etc/hosts` will get extra lines:
 
 ```
 162.242.195.82  somehost
@@ -187,12 +186,12 @@ configuration, which means for Linux `/etc/hosts` will get extra lines:
 
 ### isolation
 
-`isolation` specifies a build’s container isolation technology. Like [isolation](spec.md#isolation) supported values
+`isolation` specifies the container isolation technology at build-time. Like [isolation](spec.md#isolation), supported values
 are platform-specific.
 
 ### labels
 
-`labels` add metadata to the resulting image. `labels` can be set either as an array or a map.
+`labels` add metadata to the resulting image. `labels` can be an array or a map.
 
 reverse-DNS notation SHOULD be used to prevent labels from conflicting with those used by other software.
 
@@ -216,7 +215,7 @@ build:
 
 ### shm_size
 
-`shm_size` set the size of the shared memory (`/dev/shm` partition on Linux) allocated for building Docker image. Specify
+`shm_size` sets the size of the shared memory (`/dev/shm` partition on Linux) allocated for building the Docker image. Specify
 as an integer value representing the number of bytes or as a string expressing a [byte value](spec.md#specifying-byte-values).
 
 ```yml


### PR DESCRIPTION
When something was hard to read and it had typos and/or missing words I used that as an opportunity to simplify. I believe this remains true to the original intent. 

I only covered a few of the initial sections so I can get some feedback if this is helpful and if I should do anything different before proceeding with the rest of the document.

**What this PR does / why we need it**:

Fixing typos, missing words and some simplification of phrasing.


